### PR TITLE
users 테이블 통합, 단위테스트 코드리뷰

### DIFF
--- a/back/src/main/java/cafemate/back/domain/Users.java
+++ b/back/src/main/java/cafemate/back/domain/Users.java
@@ -31,9 +31,9 @@ public class Users {
 //    @OneToMany(mappedBy = "userLikes")
 //    private List<Likes> likes = new ArrayList<>();
 
-    @Builder
-    public Users(Integer id, String email, String name, String img_path) {
-        this.id = id;
+    @Builder //id는 자동생성이니까, 엔티티화할때 인자로 받을 필요없지만,
+    //테스트 케이스에서 id가 자동생성이 안되서 일단 id 항목도 인자로 받게 함
+    public Users(String email, String name, String img_path) {
         this.email = email;
         this.name = name;
         this.img_path = img_path;

--- a/back/src/main/java/cafemate/back/dto/users/UserSaveRequestDto.java
+++ b/back/src/main/java/cafemate/back/dto/users/UserSaveRequestDto.java
@@ -6,17 +6,16 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class UserSaveRequestDto {
-    private Integer id;
     private String name;
     private String email;
     private String img_path;
 
+    // DTO -> Entity
+    // builder 코드를 줄이기위해서
     public Users toEntity(){
         return Users.builder()
-                .id(id)
                 .email(email)
                 .name(name)
                 .img_path(img_path)

--- a/back/src/main/java/cafemate/back/dto/users/UsersResponseDto.java
+++ b/back/src/main/java/cafemate/back/dto/users/UsersResponseDto.java
@@ -6,7 +6,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 public class UsersResponseDto {
     private Integer id;

--- a/back/src/main/java/cafemate/back/service/UsersService.java
+++ b/back/src/main/java/cafemate/back/service/UsersService.java
@@ -8,6 +8,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
+import java.util.Optional;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -24,13 +27,19 @@ public class UsersService {
     // R 유저 조회
     @Transactional(readOnly = true)
     public UsersResponseDto findUser(Integer userId) {
+        validateUser(userId);
         Users user = usersRepository.getById(userId);
-        UsersResponseDto usersResponseDto = new UsersResponseDto (user);
-        return usersResponseDto;
+        return new UsersResponseDto(user);
     }
 
     // D 유저 탈퇴
     public void deleteUser(Integer userId) {
+        validateUser(userId);
         usersRepository.deleteById(userId);
+    }
+
+    // 회원이 있는 지 검증하기 - 함수화
+    public void validateUser(Integer userId) {
+        Users user = usersRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
     }
 }

--- a/back/src/test/java/cafemate/back/service/UsersServiceUnitTest.java
+++ b/back/src/test/java/cafemate/back/service/UsersServiceUnitTest.java
@@ -1,0 +1,94 @@
+package cafemate.back.service;
+
+import cafemate.back.domain.Users;
+import cafemate.back.repository.UsersRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UsersServiceUnitTest {
+
+    @Mock // 유닛테스트에서의 레포지토리 : @Mock 이용
+    private UsersRepository usersRepository;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    // 유닛테스트에서만 사용할 Mock 데이터
+    private Users getStubUser() {
+        String name = "유저네임";
+        String email = "유저@gmail.com";
+        String img_path = "유저프로필사진주소";
+
+        return Users.builder()
+                .name(name)
+                .email(email)
+                .img_path(img_path)
+                .build();
+    }
+
+    @Test
+    public void 회원가입() throws Exception {
+        //given : 저장했던 엔티티(mock 데이터로 저장)와 같은 객체 반환
+        Users user = getStubUser();
+        when(usersRepository.save(any(Users.class))).then(AdditionalAnswers.returnsFirstArg());
+
+        //when : save 실행 시, getStubComment()이 실행됨 => 저장한 Users 엔티티가 리턴
+        Users savedUser = usersRepository.save(user);
+
+        //then
+        assertEquals(savedUser.getName(), user.getName());
+        assertEquals(savedUser.getEmail(), user.getEmail());
+        assertEquals(savedUser.getImg_path(), user.getImg_path());
+    }
+
+    @Test
+    public void 회원조회() throws Exception {
+        //given
+        when(usersRepository.getById(any())).thenReturn(getStubUser());
+
+        //when
+        Users findUser = usersRepository.getById(any());
+
+        //then
+        assertEquals(findUser.getId(), getStubUser().getId());
+        assertEquals(findUser.getEmail(), getStubUser().getEmail());
+        assertEquals(findUser.getName(), getStubUser().getName());
+    }
+
+    @Test
+    public void 회원탈퇴() throws Exception {
+        //given
+        when(usersRepository.getById(any())).thenReturn(getStubUser());
+        Users comment = usersRepository.getById(any());
+        Integer userId = comment.getId();
+
+        //when
+        usersRepository.deleteById(userId);
+        Users deleteUser = usersRepository.findById(userId).orElse(null);
+
+        //then
+        assertNull(deleteUser);
+    }
+//    @Test
+//    public void 카페리뷰조회() throws Exception {
+//
+//    }
+//
+//    @Test
+//    public void 유저리뷰조회() throws Exception {
+//
+//    }
+}


### PR DESCRIPTION
안녕하세요!
users 테이블에서의 회원 저장/조회/삭제와 관련된 테스트 케이스를 작성해보았는데, 확인 부탁드립니다!
단위테스트와 통합테스트 두가지를 작성했습니다!

테스트케이스 작성하면서 
회원 조회, 탈퇴 시 없는 회원일 경우의 예외처리도 service 추가하였습니다!
3개중 2번째 커밋에 내용이 담겨있습니다! 

질문 1) 코드리뷰 부탁드립니다!

질문 2) 통합테스트(UsersServiceTest.java)는 
예전에 작성하던 것과 새로 작성한 게  내용이 전혀 다른데요,
빨간줄/초록줄로 되어있어 보기 불편한 것 같은데,
혹시 다른 방식으로 커밋을 해야할까요?

질문 3) DTO와 Entity의 변환을 Service단에서 하다보니,
service 테스트 작성 시, repository만을 주입하여 테스트하였는데요!
(저처럼 서비스단에서 변환할 경우의 깃허브 코드를 참고했습니다)
(DTO, Entity변환이 controller단이면 테스트코드에서 usersService도 주입해서 테스트 하는걸로 알고 있습니다!)

-> 저의 경우 usersService의 테스트는 빠지게 되는데, 이 부분은 따로 해주지 않아도 괜찮을까요?